### PR TITLE
minor changes to allow opinel to function from within AWS Lambda

### DIFF
--- a/opinel/utils/cli_parser.py
+++ b/opinel/utils/cli_parser.py
@@ -152,18 +152,17 @@ def read_default_args(tool_name):
     for i, arg in enumerate(sys.argv):
         if arg == '--profile' and len(sys.argv) >= i + 1:
             profile_name = sys.argv[i + 1]
-            
+    #if not os.path.isdir(opinel_arg_dir):
+    #    os.makedirs(opinel_arg_dir)            
     if not os.path.isdir(opinel_arg_dir):
         try:
-            if not os.path.exists(opinel_arg_dir):
-                os.makedirs(opinel_arg_dir)
+            os.makedirs(opinel_arg_dir)
         except:
             # Within AWS Lambda, home directories are not writable. This attempts to detect that...
             #  ...and uses the /tmp folder, which *is* writable in AWS Lambda
             opinel_arg_dir = os.path.join(tempfile.gettempdir(), '.aws/opinel')
             if not os.path.isdir(opinel_arg_dir):
                 os.makedirs(opinel_arg_dir)
-
     opinel_arg_file = os.path.join(opinel_arg_dir, '%s.json' % profile_name)
     default_args = {}
     if os.path.isfile(opinel_arg_file):

--- a/opinel/utils/cli_parser.py
+++ b/opinel/utils/cli_parser.py
@@ -158,16 +158,12 @@ def read_default_args(tool_name):
             if not os.path.exists(opinel_arg_dir):
                 os.makedirs(opinel_arg_dir)
         except:
-            # Determine if opinel_arg_dir is writable. If not or doesnt exist, create it...
-            #   ... and then set global opinel_arg_dir equal to this value
-            if not os.access(opinel_arg_dir, os.W_OK):
-                # Within AWS Lambda, home directories are not writable. This attempts to detect that...
-                #  ...and uses the /tmp folder, which *is* writable in AWS Lambda
-                opinel_arg_dir = os.path.join(tempfile.gettempdir(), '.aws/opinel')
-                if not os.path.isdir(opinel_arg_dir):
-                    os.makedirs(opinel_arg_dir)
-            else:
-                raise
+            # Within AWS Lambda, home directories are not writable. This attempts to detect that...
+            #  ...and uses the /tmp folder, which *is* writable in AWS Lambda
+            opinel_arg_dir = os.path.join(tempfile.gettempdir(), '.aws/opinel')
+            if not os.path.isdir(opinel_arg_dir):
+                os.makedirs(opinel_arg_dir)
+
     opinel_arg_file = os.path.join(opinel_arg_dir, '%s.json' % profile_name)
     default_args = {}
     if os.path.isfile(opinel_arg_file):

--- a/opinel/utils/cli_parser.py
+++ b/opinel/utils/cli_parser.py
@@ -155,8 +155,9 @@ def read_default_args(tool_name):
             
     if not os.path.isdir(opinel_arg_dir):
         try:
-            os.makedirs(opinel_arg_dir)
-        except OSError as ex:
+            if not os.path.exists(opinel_arg_dir):
+                os.makedirs(opinel_arg_dir)
+        except:
             # Determine if opinel_arg_dir is writable. If not or doesnt exist, create it...
             #   ... and then set global opinel_arg_dir equal to this value
             if not os.access(opinel_arg_dir, os.W_OK):

--- a/opinel/utils/cli_parser.py
+++ b/opinel/utils/cli_parser.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import sys
+import tempfile
 
 opinel_arg_dir = os.path.join(os.path.expanduser('~'), '.aws/opinel')
 
@@ -144,13 +145,28 @@ def read_default_args(tool_name):
     :param tool_name:                   Name of the script to read the default arguments for
     :return:                            Dictionary of default arguments (shared + tool-specific)
     """
+    global opinel_arg_dir
+    
     profile_name = 'default'
     # h4ck to have an early read of the profile name
     for i, arg in enumerate(sys.argv):
         if arg == '--profile' and len(sys.argv) >= i + 1:
             profile_name = sys.argv[i + 1]
+            
     if not os.path.isdir(opinel_arg_dir):
-        os.makedirs(opinel_arg_dir)
+        try:
+            os.makedirs(opinel_arg_dir)
+        except OSError as ex:
+            # Determine if opinel_arg_dir is writable. If not or doesnt exist, create it...
+            #   ... and then set global opinel_arg_dir equal to this value
+            if not os.access(opinel_arg_dir, os.W_OK):
+                # Within AWS Lambda, home directories are not writable. This attempts to detect that...
+                #  ...and uses the /tmp folder, which *is* writable in AWS Lambda
+                opinel_arg_dir = os.path.join(tempfile.gettempdir(), '.aws/opinel')
+                if not os.path.isdir(opinel_arg_dir):
+                    os.makedirs(opinel_arg_dir)
+            else:
+                raise
     opinel_arg_file = os.path.join(opinel_arg_dir, '%s.json' % profile_name)
     default_args = {}
     if os.path.isfile(opinel_arg_file):


### PR DESCRIPTION
I want to be able to run Scout2 from within AWS Lambda. However, within Lambda the home directory is not writable, which causes opinel to fail. This minor modification handles the exception, and when it occurs, uses `/tmp/.aws/opinel`. I'm using the `tempfile` module to correctly select the system temp dir.