### PR TITLE
Fixed incorrect key names in credentials object for AWS MFA STS authentication

### DIFF
--- a/opinel/utils/credentials.py
+++ b/opinel/utils/credentials.py
@@ -74,9 +74,9 @@ def assume_role(role_name, credentials, role_arn, role_session_name, silent = Fa
       'RoleSessionName': role_session_name
     }
     # MFA used ?
-    if 'mfa_serial' in credentials and 'mfa_code' in credentials:
-      sts_args['TokenCode'] = credentials['mfa_code']
-      sts_args['SerialNumber'] = credentials['mfa_serial']
+    if 'SerialNumber' in credentials and 'TokenCode' in credentials:
+      sts_args['TokenCode'] = credentials['TokenCode']
+      sts_args['SerialNumber'] = credentials['SerialNumber']
     # External ID used ?
     if external_id:
       sts_args['ExternalId'] = external_id


### PR DESCRIPTION
The AWS STS logic for MFA was referencing the incorrect key names in the credentials object. This has been corrected and tested.